### PR TITLE
Add support for hashtags

### DIFF
--- a/src/Qonq.BlueSky.Tests/APITests.cs
+++ b/src/Qonq.BlueSky.Tests/APITests.cs
@@ -85,6 +85,34 @@ public class APITests
         Assert.NotEmpty(postResponse.Cid);
     }
 
+    [Fact]
+    public async Task PostSomethingWithAHashTag()
+    {
+        var sessionRequest = new CreateSessionRequest()
+        {
+            Identifier = _handle,
+            Password = _password
+        };
+
+        var sessionResponse = await _client.CreateSessionAsync(sessionRequest);
+
+        Assert.NotNull(sessionResponse);
+        Assert.NotNull(sessionResponse.AccessJwt);
+        Assert.NotEmpty(sessionResponse.AccessJwt);
+
+        var text = "Beep, Beep, Boop! #HashTag";
+
+        var postResponse = await _client.CreatePostAsync(text);
+
+        Assert.NotNull(postResponse);
+
+        Assert.NotNull(postResponse.Uri);
+        Assert.NotEmpty(postResponse.Uri);
+
+        Assert.NotNull(postResponse.Cid);
+        Assert.NotEmpty(postResponse.Cid);
+    }
+
     public static string GetBase64Image(string relativePath)
     {
         // Resolve the full path

--- a/src/Qonq.BlueSky/BlueSkyClient.cs
+++ b/src/Qonq.BlueSky/BlueSkyClient.cs
@@ -349,6 +349,10 @@ namespace Qonq.BlueSky
 
             string url = $"{pdsHost}/xrpc/com.atproto.repo.createRecord";
 
+            UnicodeString utf16 = new UnicodeString(text);
+
+            var facts = Facets.DetectFacets(utf16);
+
             var createRecordRequest = new CreateRecordRequest
             {
                 Repo = _did,
@@ -357,6 +361,7 @@ namespace Qonq.BlueSky
                 {
                     Text = text,
                     CreatedAt = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ssZ"),
+                    Facets = facts,
                     Type = "app.bsky.feed.post"
                 }
             };

--- a/src/README.md
+++ b/src/README.md
@@ -122,6 +122,22 @@ Console.WriteLine($"Post CID: {postResponse.Cid}");
 
 ---
 
+### **5. Posting Content with hashtags**
+Once authenticated, you can post text content using the `CreatePostAsync` method:
+```csharp
+var postContent = "Beep, Beep, Boop! I'm a BlueSky.NET Bot! #HashTag";
+
+var postResponse = await client.CreatePostAsync(postContent);
+
+Console.WriteLine($"Post URI: {postResponse.Uri}");
+Console.WriteLine($"Post CID: {postResponse.Cid}");
+```
+
+**Validation:**
+- The `Uri` and `Cid` fields should be non-null and non-empty.
+
+---
+
 ## **Features**
 - **DID Retrieval:** Fetch your unique identifier.
 - **Session Management:** Authenticate using your handle and password.


### PR DESCRIPTION
I noticed that when using this library hashtags are not displaying correctly on BlueSky.

I believe this is because we need to create hashtags as facets. This looks to have been implemented when a post includes an image, but not when it is plaintext. This PR fixes that.